### PR TITLE
Fix `contains` for when an empty range is passed

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,11 @@ _RangeContains_ provides `contains` methods for `Range`, `ClosedRange`, `Countab
 let a: ClosedRange<Int> = 2...7
 a.contains(3...5) // `true`
 a.contains(3...7) // also `true`
-a.contains(3..<8) // still `true` because all values contained in `3..<8` are also in `a`
+a.contains(3..<8) // still `true` because all elements contained in `3..<8` are also in `a`
 a.contains(3..<9) // `false`
+a.contains(11..<11) // `true` because `11..<11` has no element
+a.contains(11...11) // `false`
+
 
 let b: ClosedRange<Float> = 2...7
 b.contains(3...5) // `true`

--- a/Sources/Range.swift
+++ b/Sources/Range.swift
@@ -8,7 +8,7 @@ extension CountableRange {
     }
 
     public func contains(_ range: Range<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound || range.lowerBound == range.upperBound
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound || range.isEmpty
     }
 
     public func contains(_ range: ClosedRange<Bound>) -> Bool {

--- a/Sources/Range.swift
+++ b/Sources/Range.swift
@@ -1,6 +1,6 @@
 extension CountableRange {
     public func contains(_ range: CountableRange<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound || range.lowerBound == range.upperBound
     }
 
     public func contains(_ range: CountableClosedRange<Bound>) -> Bool {
@@ -8,7 +8,7 @@ extension CountableRange {
     }
 
     public func contains(_ range: Range<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound || range.lowerBound == range.upperBound
     }
 
     public func contains(_ range: ClosedRange<Bound>) -> Bool {
@@ -18,7 +18,7 @@ extension CountableRange {
 
 extension CountableClosedRange {
     public func contains(_ range: CountableRange<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound.advanced(by: 1)
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound.advanced(by: 1) || range.lowerBound == range.upperBound
     }
 
     public func contains(_ range: CountableClosedRange<Bound>) -> Bool {
@@ -26,7 +26,7 @@ extension CountableClosedRange {
     }
 
     public func contains(_ range: Range<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound.advanced(by: 1)
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound.advanced(by: 1) || range.lowerBound == range.upperBound
     }
 
     public func contains(_ range: ClosedRange<Bound>) -> Bool {
@@ -36,7 +36,7 @@ extension CountableClosedRange {
 
 extension Range where Bound: Strideable, Bound.Stride: SignedInteger {
     public func contains(_ range: CountableRange<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound || range.lowerBound == range.upperBound
     }
 
     public func contains(_ range: CountableClosedRange<Bound>) -> Bool {
@@ -46,7 +46,7 @@ extension Range where Bound: Strideable, Bound.Stride: SignedInteger {
 
 extension Range {
     public func contains(_ range: Range<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound || range.lowerBound == range.upperBound
     }
 
     public func contains(_ range: ClosedRange<Bound>) -> Bool {
@@ -56,7 +56,7 @@ extension Range {
 
 extension ClosedRange where Bound: Strideable, Bound.Stride: SignedInteger {
     public func contains(_ range: CountableRange<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound.advanced(by: 1)
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound.advanced(by: 1) || range.lowerBound == range.upperBound
     }
 
     public func contains(_ range: CountableClosedRange<Bound>) -> Bool {
@@ -64,13 +64,13 @@ extension ClosedRange where Bound: Strideable, Bound.Stride: SignedInteger {
     }
 
     public func contains(_ range: Range<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound.advanced(by: 1)
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound.advanced(by: 1) || range.lowerBound == range.upperBound
     }
 }
 
 extension ClosedRange {
     public func contains(_ range: Range<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound || range.lowerBound == range.upperBound
     }
 
     public func contains(_ range: ClosedRange<Bound>) -> Bool {

--- a/Sources/Range.swift
+++ b/Sources/Range.swift
@@ -1,6 +1,6 @@
 extension CountableRange {
     public func contains(_ range: CountableRange<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound || range.lowerBound == range.upperBound
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound || range.isEmpty
     }
 
     public func contains(_ range: CountableClosedRange<Bound>) -> Bool {
@@ -18,7 +18,7 @@ extension CountableRange {
 
 extension CountableClosedRange {
     public func contains(_ range: CountableRange<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound.advanced(by: 1) || range.lowerBound == range.upperBound
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound.advanced(by: 1) || range.isEmpty
     }
 
     public func contains(_ range: CountableClosedRange<Bound>) -> Bool {
@@ -26,7 +26,7 @@ extension CountableClosedRange {
     }
 
     public func contains(_ range: Range<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound.advanced(by: 1) || range.lowerBound == range.upperBound
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound.advanced(by: 1) || range.isEmpty
     }
 
     public func contains(_ range: ClosedRange<Bound>) -> Bool {
@@ -36,7 +36,7 @@ extension CountableClosedRange {
 
 extension Range where Bound: Strideable, Bound.Stride: SignedInteger {
     public func contains(_ range: CountableRange<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound || range.lowerBound == range.upperBound
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound || range.isEmpty
     }
 
     public func contains(_ range: CountableClosedRange<Bound>) -> Bool {
@@ -46,7 +46,7 @@ extension Range where Bound: Strideable, Bound.Stride: SignedInteger {
 
 extension Range {
     public func contains(_ range: Range<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound || range.lowerBound == range.upperBound
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound || range.isEmpty
     }
 
     public func contains(_ range: ClosedRange<Bound>) -> Bool {
@@ -56,7 +56,7 @@ extension Range {
 
 extension ClosedRange where Bound: Strideable, Bound.Stride: SignedInteger {
     public func contains(_ range: CountableRange<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound.advanced(by: 1) || range.lowerBound == range.upperBound
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound.advanced(by: 1) || range.isEmpty
     }
 
     public func contains(_ range: CountableClosedRange<Bound>) -> Bool {
@@ -64,13 +64,13 @@ extension ClosedRange where Bound: Strideable, Bound.Stride: SignedInteger {
     }
 
     public func contains(_ range: Range<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound.advanced(by: 1) || range.lowerBound == range.upperBound
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound.advanced(by: 1) || range.isEmpty
     }
 }
 
 extension ClosedRange {
     public func contains(_ range: Range<Bound>) -> Bool {
-        return lowerBound <= range.lowerBound && range.upperBound <= upperBound || range.lowerBound == range.upperBound
+        return lowerBound <= range.lowerBound && range.upperBound <= upperBound || range.isEmpty
     }
 
     public func contains(_ range: ClosedRange<Bound>) -> Bool {

--- a/Tests/RangeContainsTests/RangeContainsTests.swift
+++ b/Tests/RangeContainsTests/RangeContainsTests.swift
@@ -6,13 +6,17 @@ class RangeContainsTests: XCTestCase {
         let a: ClosedRange<Int> = 2...7
         _ = a.contains(3...5) // `true`
         _ = a.contains(3...7) // also `true`
-        _ = a.contains(3..<8) // still `true` because all values contained in `3..<8` are also in `a`
+        _ = a.contains(3..<8) // still `true` because all elements contained in `3..<8` are also in `a`
         _ = a.contains(3..<9) // `false`
+        _ = a.contains(11..<11) // `true` because `11..<11` has no element
+        _ = a.contains(11...11) // `false`
 
         XCTAssertTrue(a.contains(3...5))
         XCTAssertTrue(a.contains(3...7))
         XCTAssertTrue(a.contains(3..<8))
         XCTAssertFalse(a.contains(3..<9))
+        XCTAssertTrue(a.contains(11..<11))
+        XCTAssertFalse(a.contains(11...11))
         
         let b: ClosedRange<Float> = 2...7
         _ = b.contains(3...5) // `true`

--- a/Tests/RangeContainsTests/RangeTests.swift
+++ b/Tests/RangeContainsTests/RangeTests.swift
@@ -152,6 +152,27 @@ class RangeTests: XCTestCase {
                 XCTAssertFalse(a.contains(b))
                 XCTAssertFalse(CountableClosedRange(b).reduce(true) { $0 && a.contains($1) })
             }
+
+            do {
+                let b: CountableRange<Int> = 11..<11
+                XCTAssertTrue(a.contains(b))
+                XCTAssertTrue(b.reduce(true) { $0 && a.contains($1) })
+            }
+            do {
+                let b: CountableClosedRange<Int> = 11...11
+                XCTAssertFalse(a.contains(b))
+                XCTAssertFalse(b.reduce(true) { $0 && a.contains($1) })
+            }
+            do {
+                let b: Range<Int> = 11..<11
+                XCTAssertTrue(a.contains(b))
+                XCTAssertTrue(CountableRange(b).reduce(true) { $0 && a.contains($1) })
+            }
+            do {
+                let b: ClosedRange<Int> = 11...11
+                XCTAssertFalse(a.contains(b))
+                XCTAssertFalse(CountableClosedRange(b).reduce(true) { $0 && a.contains($1) })
+            }
         }
     }
 
@@ -302,6 +323,27 @@ class RangeTests: XCTestCase {
             }
             do {
                 let b: ClosedRange<Int> = 3...9
+                XCTAssertFalse(a.contains(b))
+                XCTAssertFalse(CountableClosedRange(b).reduce(true) { $0 && a.contains($1) })
+            }
+
+            do {
+                let b: CountableRange<Int> = 11..<11
+                XCTAssertTrue(a.contains(b))
+                XCTAssertTrue(b.reduce(true) { $0 && a.contains($1) })
+            }
+            do {
+                let b: CountableClosedRange<Int> = 11...11
+                XCTAssertFalse(a.contains(b))
+                XCTAssertFalse(b.reduce(true) { $0 && a.contains($1) })
+            }
+            do {
+                let b: Range<Int> = 11..<11
+                XCTAssertTrue(a.contains(b))
+                XCTAssertTrue(CountableRange(b).reduce(true) { $0 && a.contains($1) })
+            }
+            do {
+                let b: ClosedRange<Int> = 11...11
                 XCTAssertFalse(a.contains(b))
                 XCTAssertFalse(CountableClosedRange(b).reduce(true) { $0 && a.contains($1) })
             }
@@ -458,6 +500,27 @@ class RangeTests: XCTestCase {
                 XCTAssertFalse(a.contains(b))
                 XCTAssertFalse(CountableClosedRange(b).reduce(true) { $0 && a.contains($1) })
             }
+
+            do {
+                let b: CountableRange<Int> = 11..<11
+                XCTAssertTrue(a.contains(b))
+                XCTAssertTrue(b.reduce(true) { $0 && a.contains($1) })
+            }
+            do {
+                let b: CountableClosedRange<Int> = 11...11
+                XCTAssertFalse(a.contains(b))
+                XCTAssertFalse(b.reduce(true) { $0 && a.contains($1) })
+            }
+            do {
+                let b: Range<Int> = 11..<11
+                XCTAssertTrue(a.contains(b))
+                XCTAssertTrue(CountableRange(b).reduce(true) { $0 && a.contains($1) })
+            }
+            do {
+                let b: ClosedRange<Int> = 11...11
+                XCTAssertFalse(a.contains(b))
+                XCTAssertFalse(CountableClosedRange(b).reduce(true) { $0 && a.contains($1) })
+            }
         }
 
         do {
@@ -523,6 +586,15 @@ class RangeTests: XCTestCase {
             }
             do {
                 let b: ClosedRange<Float> = 3...9
+                XCTAssertFalse(a.contains(b))
+            }
+
+            do {
+                let b: Range<Float> = 11..<11
+                XCTAssertTrue(a.contains(b))
+            }
+            do {
+                let b: ClosedRange<Float> = 11...11
                 XCTAssertFalse(a.contains(b))
             }
         }
@@ -678,6 +750,27 @@ class RangeTests: XCTestCase {
                 XCTAssertFalse(a.contains(b))
                 XCTAssertFalse(CountableClosedRange(b).reduce(true) { $0 && a.contains($1) })
             }
+
+            do {
+                let b: CountableRange<Int> = 11..<11
+                XCTAssertTrue(a.contains(b))
+                XCTAssertTrue(b.reduce(true) { $0 && a.contains($1) })
+            }
+            do {
+                let b: CountableClosedRange<Int> = 11...11
+                XCTAssertFalse(a.contains(b))
+                XCTAssertFalse(b.reduce(true) { $0 && a.contains($1) })
+            }
+            do {
+                let b: Range<Int> = 11..<11
+                XCTAssertTrue(a.contains(b))
+                XCTAssertTrue(CountableRange(b).reduce(true) { $0 && a.contains($1) })
+            }
+            do {
+                let b: ClosedRange<Int> = 11...11
+                XCTAssertFalse(a.contains(b))
+                XCTAssertFalse(CountableClosedRange(b).reduce(true) { $0 && a.contains($1) })
+            }
         }
 
         do {
@@ -743,6 +836,15 @@ class RangeTests: XCTestCase {
             }
             do {
                 let b: ClosedRange<Float> = 3...9
+                XCTAssertFalse(a.contains(b))
+            }
+
+            do {
+                let b: Range<Float> = 11..<11
+                XCTAssertTrue(a.contains(b))
+            }
+            do {
+                let b: ClosedRange<Float> = 11...11
                 XCTAssertFalse(a.contains(b))
             }
         }

--- a/Tests/RangeContainsTests/RangeTests.swift.gyb
+++ b/Tests/RangeContainsTests/RangeTests.swift.gyb
@@ -22,13 +22,15 @@ class RangeTests: XCTestCase {
         %     end
         do {
             let a: ${range_type_1}<${bound_type}> = 2${'...' if closed_1 else '..<'}7
-            % for lower, upper in [(3, 5), (2, 5), (3, 7), (2, 7), (1, 5), (3, 8), (3, 9)]:
+            % for lower, upper in [(3, 5), (2, 5), (3, 7), (2, 7), (1, 5), (3, 8), (3, 9), (11, 11)]:
 
             %     for range_type_2 in range_types if bound_type == 'Int' else [r for r in range_types if 'Countable' not in r]:
             %         closed_2 = 'Closed' in range_type_2
             do {
                 let b: ${range_type_2}<${bound_type}> = ${lower}${'...' if closed_2 else '..<'}${upper}
-                %     if lower < 2:
+                %     if lower == 11 and upper == 11:
+                %         contained = not closed_2 
+                %     elif lower < 2:
                 %         contained = False
                 %     elif upper < 7:
                 %         contained = True
@@ -48,6 +50,8 @@ class RangeTests: XCTestCase {
                 %         end
                 %     elif upper >= 9:
                 %         contained = False
+                %     else:
+                %         raise Exception('Never reaches here.')
                 %     end
                 XCTAssert${'True' if contained else 'False'}(a.contains(b))
                 %


### PR DESCRIPTION
`(2...7).contains(11..<11)` must return `true`.